### PR TITLE
feat: make generated code more idiomatic to zig users

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Install Zig
         uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.13.0
   
       - name: Check Zig Version
         run: zig version

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-bindgen": "1.0.0-rc.5",
+        "@dylibso/xtp-bindgen": "1.0.0-rc.7",
         "ejs": "^3.1.10"
       },
       "devDependencies": {
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@dylibso/xtp-bindgen": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.5.tgz",
-      "integrity": "sha512-F+s0XA5NeS7q6ikWe7Qou8AsLqYJfCQQbFEpgzWsqIh3YoLF7jcEwgc3Df60FbRocitOf/ZRlCxgaqJlAuD73w=="
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.7.tgz",
+      "integrity": "sha512-8nMT8xqsC6FYVT2tS4xB3R+VVYAfiu6AceZLlRjfB2SCE5H6YqgX0INU9ZL9IacvFr+mRjEoQZ6B+G4Y/WR9WQ=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@dylibso/xtp-bindgen": "1.0.0-rc.5",
+    "@dylibso/xtp-bindgen": "1.0.0-rc.7",
     "ejs": "^3.1.10"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@ import ejs from "ejs";
 import { getContext, helpers, Property, XtpSchema } from "@dylibso/xtp-bindgen";
 
 function toZigType(property: Property, pkg?: string): string {
-  if (property.$ref) return (pkg ? `${pkg}.` : "") + property.$ref.name;
+  if (property.$ref) {
+    return (pkg ? `${pkg}.` : "") + zigTypeName(property.$ref.name);
+  }
   switch (property.type) {
     case "string":
       if (property.format === "date-time") {
@@ -54,7 +56,16 @@ function addStdImport(schema: XtpSchema) {
     : null;
 }
 
-function makeStructName(s: string) {
+function zigFuncName(s: string) {
+  return helpers.snakeToCamelCase(s);
+}
+
+function zigVarName(s: string) {
+  return helpers.camelToSnakeCase(s);
+}
+
+function zigTypeName(s: string) {
+  s = helpers.snakeToCamelCase(s);
   const cap = s.charAt(0).toUpperCase();
   if (s.charAt(0) === cap) {
     return s;
@@ -71,8 +82,10 @@ export function render() {
     ...getContext(),
     toZigType,
     pointerToZigType,
-    makeStructName,
     addStdImport,
+    zigTypeName,
+    zigFuncName,
+    zigVarName,
   };
 
   const output = ejs.render(tmpl, ctx);

--- a/template/src/main.zig.ejs
+++ b/template/src/main.zig.ejs
@@ -12,7 +12,7 @@ const schema = @import("schema.zig");
 /// And returns <%- toZigType(ex.output) %> (<%- formatCommentLine(ex.output.description) %>)
 <% } -%>
 <% -%>
-pub fn <%- ex.name %>(<%- ex.input ? `input: ${toZigType(ex.input, "schema")}` : null %>) !<%- ex.output ? `${toZigType(ex.output, "schema")}` : "void" %> {
+pub fn <%- zigFuncName(ex.name) %>(<%- ex.input ? `input: ${toZigType(ex.input, "schema")}` : null %>) !<%- ex.output ? `${toZigType(ex.output, "schema")}` : "void" %> {
 	<% if (featureFlags['stub-with-code-samples'] && codeSamples(ex, 'zig').length > 0) { -%>
 		<%- codeSamples(ex, 'zig')[0].source %>
 	<% } else { -%>

--- a/template/src/pdk.zig.ejs
+++ b/template/src/pdk.zig.ejs
@@ -78,13 +78,13 @@ export fn <%- ex.name %>() i32 {
 
 	// Call the implementation function
     <% if (ex.output) { -%>
-    const output = user.<%- ex.name %>(<% if (ex.input) { %>input<% } %>) catch |err| {
+    const output = user.<%- zigFuncName(ex.name) %>(<% if (ex.input) { %>input<% } %>) catch |err| {
         const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
         _plugin.setError(msg);
         return -1;
     };
     <% } else { -%>
-    user.<%- ex.name %>(input) catch |err| {
+    user.<%- zigFuncName(ex.name) %>(input) catch |err| {
         const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
         _plugin.setError(msg);
         return -1;
@@ -92,13 +92,13 @@ export fn <%- ex.name %>() i32 {
     <% } -%>
   <% } else { -%>
     <% if (ex.output) { -%>
-    const output = user.<%- ex.name %>() catch |err| {
+    const output = user.<%- zigFuncName(ex.name) %>() catch |err| {
         const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
         _plugin.setError(msg);
         return -1;
     };
     <% } else { -%>
-    user.<%- ex.name %>() catch |err| {
+    user.<%- zigFuncName(ex.name) %>() catch |err| {
         const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
         _plugin.setError(msg);
         return -1;

--- a/template/src/schema.zig.ejs
+++ b/template/src/schema.zig.ejs
@@ -28,7 +28,7 @@ pub const Host = struct {
 	<% if (imp.output && hasComment(imp.output)) { -%>
 	/// And it returns an output <%- toZigType(imp.output) %> (<%- formatCommentLine(imp.output.description) %>)
 	<% } -%>
-	pub fn <%- imp.name %>(<%- imp.input ? `input: ${toZigType(imp.input)}` : null %>) !<%- imp.output ? `${toZigType(imp.output)}` : "void" %> {
+	pub fn <%- zigFuncName(imp.name) %>(<%- imp.input ? `input: ${toZigType(imp.input)}` : null %>) !<%- imp.output ? `${toZigType(imp.output)}` : "void" %> {
 	<% if (imp.input) { -%>
 		<% if (imp.input.contentType === 'application/json') { -%>
 		const b = try std.json.stringifyAlloc(_plugin.allocator, input, .{});
@@ -90,7 +90,7 @@ pub const Host = struct {
 <% Object.values(schema.schemas).forEach(schema => { %>
 	<% if (schema.properties.length > 0) { -%>
 	/// <%- formatCommentBlock(schema.description, "/// ") %>
-	pub const <%- makeStructName(schema.name) %> = struct {
+	pub const <%- zigTypeName(schema.name) %> = struct {
 		<% schema.properties.forEach(p => { -%>
 		<% if (p.description) { -%>
 		/// <%- formatCommentBlock(p.description, "/// ") %>
@@ -102,7 +102,7 @@ pub const Host = struct {
 			<% if (schema.description) { -%>
 			/// <%- formatCommentBlock(schema.description, "/// ") %>
 			<% } -%>
-			pub const <%- makeStructName(schema.name) %> = enum {
+			pub const <%- zigTypeName(schema.name) %> = enum {
 				<% schema.enum.forEach((variant) => { -%>
 				<%- variant %>,
 				<% }) -%>

--- a/tests/schemas/fruit.yaml
+++ b/tests/schemas/fruit.yaml
@@ -1,4 +1,13 @@
 exports:
+  snake_case_func_name:
+      description: This is a function that uses snake case in the name
+      input:
+        type: string
+        contentType: text/plain; charset=utf-8
+        description: A string passed into plugin input
+      output:
+        $ref: "#/components/schemas/some_value"
+        contentType: application/json
   voidFunc:
     description: "This demonstrates how you can create an export with\nno inputs or
       outputs. \n"
@@ -69,6 +78,11 @@ imports:
 version: v1-draft
 components:
   schemas:
+    some_value:
+      properties:
+        a_string:
+          type: string
+          description: a string
     WriteParams:
       properties:
         key:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -11,6 +11,7 @@ for file in ./schemas/*.yaml; do
   rm -rf output
   xtp plugin init --schema-file $file --template ../bundle --path output -y --feature stub-with-code-samples --name output
   cd output
-  xtp plugin build
+  # xtp plugin build
+  zig build
   cd ..
 done

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -11,7 +11,6 @@ for file in ./schemas/*.yaml; do
   rm -rf output
   xtp plugin init --schema-file $file --template ../bundle --path output -y --feature stub-with-code-samples --name output
   cd output
-  # xtp plugin build
-  zig build
+  xtp plugin build
   cd ..
 done


### PR DESCRIPTION
Convert any end-user facing identifier to a more Zig-friendly option, using the latest helpers in `xtp-bindgen`. e.g.: 

For this schema portion:

```yaml
snake_case_func_name:
    description: This is a function that uses snake case in the name
    input:
      type: string
      contentType: text/plain; charset=utf-8
      description: A string passed into plugin input
    output:
      $ref: "#/components/schemas/some_value"
      contentType: application/json
#...
components:
  schemas:
    some_value:
      properties:
        a_string:
          type: string
          description: a string
```

We now produce:  

```zig
/// This is a function that uses snake case in the name
/// It takes []const u8 as input (A string passed into plugin input)
/// And returns SomeValue ()
pub fn snakeCaseFuncName(input: []const u8) !schema.SomeValue {
    // TODO: fill out your implementation here
    _ = input;
    return error.PluginFunctionNotImplemented;
}
```