### PR TITLE
feat: convert buffers to base64 for json contentType

### DIFF
--- a/template/src/pdk.zig.ejs
+++ b/template/src/pdk.zig.ejs
@@ -23,17 +23,19 @@ export fn <%- ex.name %>() i32 {
       };
       defer json_input.deinit();
       
-      var input = json_input.value();
-      // decode all the inner buffer fields from base64 (may be no-op)
-      input = (input.__decodeBase64Fields() catch |err| {
-        const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
-        _plugin.setError(msg);
-        return -1;
-      }).*;
+      <% if (!ex.input.$ref.enum) { %>
+        var input = json_input.value();
+        // decode all the inner buffer fields from base64 (may be no-op)
+        input = (input.XXX__decodeBase64Fields() catch |err| {
+          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+          _plugin.setError(msg);
+          return -1;
+        }).*;
+      <% } %>
 
       <% } else if (ex.input.type === 'buffer') { -%>
       var input = json_input.value();
-      var b64dec = std.base64.standard_no_pad.Decoder;
+      var b64dec = std.base64.standard.Decoder;
       const n = b64dec.calcSizeForSlice(input) catch |err| {
         const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
         _plugin.setError(msg);
@@ -105,6 +107,9 @@ export fn <%- ex.name %>() i32 {
     <% } -%>
 
 	// Call the implementation function
+    <% if (ex.input.$ref && ex.input.$ref.enum) { -%>
+    const input = json_input.value();
+    <% } -%>
     <% if (ex.output) { -%>
     const output = user.<%- zigFuncName(ex.name) %>(<% if (ex.input) { %>input<% } %>) catch |err| {
         const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
@@ -136,45 +141,54 @@ export fn <%- ex.name %>() i32 {
 
   <% if (ex.output) { -%>
     <% if (ex.output.contentType === 'application/json') { -%>
-    var json_output = output;
-    <% if (ex.output.$ref) { -%>
-    // encode all the inner buffer fields to base64 (may be no-op)
-    json_output = (json_output.__encodeBase64Fields() catch |err| {
-      const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
-      _plugin.setError(msg);
+      <% if (ex.output.$ref && !ex.output.$ref.enum) { -%>
+        var json_output = output;
+        // encode all the inner buffer fields to base64 (may be no-op)
+        json_output = (json_output.XXX__encodeBase64Fields() catch |err| {
+          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+          _plugin.setError(msg);
+          return -1;
+        }).*;
+        _plugin.outputJson(json_output, .{}) catch |err| {
+          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+          _plugin.setError(msg);
+          return -1;
+        };
+      <% } else if (ex.output.type === 'buffer') { -%>
+        var json_output = output;
+        var b64enc = std.base64.standard.Encoder;
+        const out_n = b64enc.calcSize(json_output.len) catch |err| {
+          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+          _plugin.setError(msg);
+          return -1;
+        };
+        const out_dest = _plugin.allocator.alloc(u8, out_n) catch |err| {
+          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+          _plugin.setError(msg);
+          return -1;
+        };
+        json_output = b64enc.encode(out_dest, json_output) catch |err| {
+          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+          _plugin.setError(msg);
+          return -1;
+        };
+        _plugin.outputJson(json_output, .{}) catch |err| {
+          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+          _plugin.setError(msg);
+          return -1;
+        };
+      <% } else { %>
+        _plugin.outputJson(output, .{}) catch |err| {
+          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+          _plugin.setError(msg);
+          return -1;
+        };
+      <% } -%>
+    <% } else if (ex.output.contentType === 'text/plain; charset=UTF-8') { -%>
+    if (!std.unicode.utf8ValidateSlice(output)) {
+      _plugin.setError("output is not valud UTF8");
       return -1;
-    }).*;
-    <% } else if (ex.output.type === 'buffer') { -%>
-    var b64enc = std.base64.standard_no_pad.Encoder;
-    const out_n = b64enc.calcSize(json_output.len) catch |err| {
-      const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
-      _plugin.setError(msg);
-      return -1;
-    };
-    const out_dest = _plugin.allocator.alloc(u8, out_n) catch |err| {
-      const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
-      _plugin.setError(msg);
-      return -1;
-    };
-    b64enc.encode(out_dest, json_output) catch |err| {
-      const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
-      _plugin.setError(msg);
-      return -1;
-    };
-    json_output = out_dest;
-    <% } -%>
-    _plugin.outputJson(json_output, .{}) catch |err| {
-        const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
-        _plugin.setError(msg);
-        return -1;
-    };
-    <% } else if (ex.output.type === 'text/plain; charset=UTF-8') { -%>
-    if (!std.unicode.utf8ValidateSlice(input)) {
-      return error.InvalidUtf8;
     }
-    _plugin.output(output);
-    <% } else if (ex.output.type === 'string') { -%>
-    _plugin.output(output);
     <% } else { -%>
     _plugin.output(output);
     <% } -%>

--- a/template/src/pdk.zig.ejs
+++ b/template/src/pdk.zig.ejs
@@ -16,39 +16,67 @@ export fn <%- ex.name %>() i32 {
     <% if (ex.input.contentType === 'application/json') { -%>
     // in JSON
       <% if (ex.input.$ref) { -%>
-      const json_input = _plugin.getJsonOpt(schema.<%- ex.input.$ref.name %>, .{}) catch |err| {
+      const json_input = _plugin.getJsonOpt(schema.<%- zigTypeName(ex.input.$ref.name) %>, .{}) catch |err| {
           const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
           _plugin.setError(msg);
           return -1;
       };
       defer json_input.deinit();
-      const input = json_input.value();
+      
+      var input = json_input.value();
+      // decode all the inner buffer fields from base64 (may be no-op)
+      input = (input.__decodeBase64Fields() catch |err| {
+        const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+        _plugin.setError(msg);
+        return -1;
+      }).*;
+
+      <% } else if (ex.input.type === 'buffer') { -%>
+      var input = json_input.value();
+      var b64dec = std.base64.standard_no_pad.Decoder;
+      const n = b64dec.calcSizeForSlice(input) catch |err| {
+        const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+        _plugin.setError(msg);
+        return -1;
+      };
+      const dest = _plugin.allocator.alloc(u8, n) catch |err| {
+        const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+        _plugin.setError(msg);
+        return -1;
+      };
+      b64dec.decode(dest, input) catch |err| {
+        const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+        _plugin.setError(msg);
+        return -1;
+      };
+      input = dest;
+
       <% } else if (ex.input.type === 'object') { -%>
-        const s = _plugin.getInput() catch |err| {
-          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
-          _plugin.setError(msg);
-          return -1;
-        };
-        defer _plugin.allocator.free(s);
-        const parsed_input = std.json.parseFromSlice(std.json.ArrayHashMap(std.json.Value), _plugin.allocator, s, .{ .allocate = .alloc_always }) catch |err| {
-          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
-          _plugin.setError(msg);
-          return -1;
-        };
-        const input = parsed_input.value;
+      const s = _plugin.getInput() catch |err| {
+        const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+        _plugin.setError(msg);
+        return -1;
+      };
+      defer _plugin.allocator.free(s);
+      const parsed_input = std.json.parseFromSlice(std.json.ArrayHashMap(std.json.Value), _plugin.allocator, s, .{ .allocate = .alloc_always }) catch |err| {
+        const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+        _plugin.setError(msg);
+        return -1;
+      };
+      const input = parsed_input.value;
       <% } else { -%> 
-        const s = _plugin.getInput() catch |err| {
-          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
-          _plugin.setError(msg);
-          return -1;
-        };
-        defer _plugin.allocator.free(s);
-        const parsed_input = std.json.parseFromSlice(<%- toZigType(ex.input) %>, _plugin.allocator, s, .{ .allocate = .alloc_always }) catch |err| {
-          const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
-          _plugin.setError(msg);
-          return -1;
-        };
-        const input = parsed_input.value;
+      const s = _plugin.getInput() catch |err| {
+        const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+        _plugin.setError(msg);
+        return -1;
+      };
+      defer _plugin.allocator.free(s);
+      const parsed_input = std.json.parseFromSlice(<%- toZigType(ex.input) %>, _plugin.allocator, s, .{ .allocate = .alloc_always }) catch |err| {
+        const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+        _plugin.setError(msg);
+        return -1;
+      };
+      const input = parsed_input.value;
       <% } -%> 
     
     <% } else if (ex.input.type === 'string') { -%>
@@ -108,7 +136,34 @@ export fn <%- ex.name %>() i32 {
 
   <% if (ex.output) { -%>
     <% if (ex.output.contentType === 'application/json') { -%>
-    _plugin.outputJson(output, .{}) catch |err| {
+    var json_output = output;
+    <% if (ex.output.$ref) { -%>
+    // encode all the inner buffer fields to base64 (may be no-op)
+    json_output = (json_output.__encodeBase64Fields() catch |err| {
+      const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+      _plugin.setError(msg);
+      return -1;
+    }).*;
+    <% } else if (ex.output.type === 'buffer') { -%>
+    var b64enc = std.base64.standard_no_pad.Encoder;
+    const out_n = b64enc.calcSize(json_output.len) catch |err| {
+      const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+      _plugin.setError(msg);
+      return -1;
+    };
+    const out_dest = _plugin.allocator.alloc(u8, out_n) catch |err| {
+      const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+      _plugin.setError(msg);
+      return -1;
+    };
+    b64enc.encode(out_dest, json_output) catch |err| {
+      const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
+      _plugin.setError(msg);
+      return -1;
+    };
+    json_output = out_dest;
+    <% } -%>
+    _plugin.outputJson(json_output, .{}) catch |err| {
         const msg = std.fmt.allocPrint(_plugin.allocator, "{}", .{err}) catch ERR_PRINTING_MSG;
         _plugin.setError(msg);
         return -1;

--- a/template/src/schema.zig.ejs
+++ b/template/src/schema.zig.ejs
@@ -97,15 +97,48 @@ pub const Host = struct {
 		<% } -%>
 		<%- p.name %>: <%- p.nullable ? "?" : null %><%- toZigType(p) %>,
 		<% }) %>
+
+		pub fn __decodeBase64Fields(self: *<%- zigTypeName(schema.name) %>) !*<%- zigTypeName(schema.name) %> {
+			<% if (schema.properties.some(p => { return p.type === 'buffer' })) { -%>
+			var b64dec = std.base64.standard_no_pad.Decoder;
+			<% } %>
+			<% schema.properties.forEach(p => { -%>
+			<% if (p.$ref && !p.$ref.enum) { %>
+			self.<%- p.name %> = (try self.<%- p.name %>.__decodeBase64Fields()).*;
+			<% } else if (p.type === 'buffer') { %>
+			const dest_<%- p.name %> = try std.heap.wasm_allocator.alloc(u8, try b64dec.calcSizeForSlice(self.<%- p.name %>));
+			try b64dec.decode(dest_<%- p.name %>, self.<%- p.name %>);
+			self.<%- p.name %> = dest_<%- p.name %>;
+			<% } %>
+			<% }) %>
+
+			return self;
+		}
+
+		pub fn __encodeBase64Fields(self: *<%- zigTypeName(schema.name) %>) !*<%- zigTypeName(schema.name) %> {
+			<% if (schema.properties.some(p => { return p.type === 'buffer' })) { -%>
+			var b64enc = std.base64.standard.Encoder;
+			<% } %>
+			<% schema.properties.forEach(p => { -%>
+			<% if (p.$ref && !p.$ref.enum) { %>
+			self.<%- p.name %> = (try self.<%- p.name %>.__encodeBase64Fields()).*;
+			<% } else if (p.type === 'buffer') { %>
+			const dest_<%- p.name %> = try std.heap.wasm_allocator.alloc(u8, b64enc.calcSize(self.<%- p.name %>.len));
+			self.<%- p.name %> = b64enc.encode(dest_<%- p.name %>, self.<%- p.name %>);
+			<% } %>
+			<% }) %>
+
+			return self;
+		}
 	};
-    <% } else if (schema.enum) { %>
-			<% if (schema.description) { -%>
-			/// <%- formatCommentBlock(schema.description, "/// ") %>
-			<% } -%>
-			pub const <%- zigTypeName(schema.name) %> = enum {
-				<% schema.enum.forEach((variant) => { -%>
-				<%- variant %>,
-				<% }) -%>
-			};
-    <% } -%>
+	<% } else if (schema.enum) { %>
+		<% if (schema.description) { -%>
+		/// <%- formatCommentBlock(schema.description, "/// ") %>
+		<% } -%>
+		pub const <%- zigTypeName(schema.name) %> = enum {
+			<% schema.enum.forEach((variant) => { -%>
+			<%- variant %>,
+			<% }) -%>
+		};
+	<% } -%>
 <% }) %>

--- a/template/src/schema.zig.ejs
+++ b/template/src/schema.zig.ejs
@@ -100,7 +100,7 @@ pub const Host = struct {
 
 		pub fn __decodeBase64Fields(self: *<%- zigTypeName(schema.name) %>) !*<%- zigTypeName(schema.name) %> {
 			<% if (schema.properties.some(p => { return p.type === 'buffer' })) { -%>
-			var b64dec = std.base64.standard_no_pad.Decoder;
+			var b64dec = std.base64.standard.Decoder;
 			<% } %>
 			<% schema.properties.forEach(p => { -%>
 			<% if (p.$ref && !p.$ref.enum) { %>

--- a/template/src/schema.zig.ejs
+++ b/template/src/schema.zig.ejs
@@ -98,13 +98,14 @@ pub const Host = struct {
 		<%- p.name %>: <%- p.nullable ? "?" : null %><%- toZigType(p) %>,
 		<% }) %>
 
-		pub fn __decodeBase64Fields(self: *<%- zigTypeName(schema.name) %>) !*<%- zigTypeName(schema.name) %> {
+		/// Internally used function, should not be called by plugin authors.
+		pub fn XXX__decodeBase64Fields(self: *<%- zigTypeName(schema.name) %>) !*<%- zigTypeName(schema.name) %> {
 			<% if (schema.properties.some(p => { return p.type === 'buffer' })) { -%>
 			var b64dec = std.base64.standard.Decoder;
 			<% } %>
 			<% schema.properties.forEach(p => { -%>
 			<% if (p.$ref && !p.$ref.enum) { %>
-			self.<%- p.name %> = (try self.<%- p.name %>.__decodeBase64Fields()).*;
+			self.<%- p.name %> = (try self.<%- p.name %>.<%- p.nullable ? '?.' : null %>XXX__decodeBase64Fields()).*;
 			<% } else if (p.type === 'buffer') { %>
 			const dest_<%- p.name %> = try std.heap.wasm_allocator.alloc(u8, try b64dec.calcSizeForSlice(self.<%- p.name %>));
 			try b64dec.decode(dest_<%- p.name %>, self.<%- p.name %>);
@@ -115,13 +116,14 @@ pub const Host = struct {
 			return self;
 		}
 
-		pub fn __encodeBase64Fields(self: *<%- zigTypeName(schema.name) %>) !*<%- zigTypeName(schema.name) %> {
+		/// Internally used function, should not be called by plugin authors.
+		pub fn XXX__encodeBase64Fields(self: *<%- zigTypeName(schema.name) %>) !*<%- zigTypeName(schema.name) %> {
 			<% if (schema.properties.some(p => { return p.type === 'buffer' })) { -%>
 			var b64enc = std.base64.standard.Encoder;
 			<% } %>
 			<% schema.properties.forEach(p => { -%>
 			<% if (p.$ref && !p.$ref.enum) { %>
-			self.<%- p.name %> = (try self.<%- p.name %>.__encodeBase64Fields()).*;
+			self.<%- p.name %> = (try self.<%- p.name %>.<%- p.nullable ? '?.' : null %>XXX__encodeBase64Fields()).*;
 			<% } else if (p.type === 'buffer') { %>
 			const dest_<%- p.name %> = try std.heap.wasm_allocator.alloc(u8, b64enc.calcSize(self.<%- p.name %>.len));
 			self.<%- p.name %> = b64enc.encode(dest_<%- p.name %>, self.<%- p.name %>);


### PR DESCRIPTION
This adds conversion functions for all generated types which handles `[]const u8` data and encodes/decodes base64 before passing back and forth across the wasm boundary. 

Of note: all schema types now have `__decodeBase64Fields` and `__encodeBase64Fields` public methods. I couldn't get private methods to work, since we import these types around the generated code... if anyone has ideas of how to improve this, or make it more clear via naming that these shouldn't really be called, let me know!

I thought of `XXX__decodeBase64Fields` or something along those lines, which I think protobuf does in Go for example... and would be open to it. But it's a little jarring IMO to see these in your autocomplete etc. Maybe its more clear?

CI likely fails until we merge & release https://github.com/dylibso/xtp-bindgen-test/pull/10